### PR TITLE
Making collections::Array iterable

### DIFF
--- a/zero/ifc/collections/array.cppm
+++ b/zero/ifc/collections/array.cppm
@@ -7,6 +7,8 @@ export module array;
 import std;
 import typedefs;
 import concepts;
+import iterator;
+import container;
 
 using namespace zero;
 
@@ -26,9 +28,14 @@ export namespace zero::collections {
      * will be zero initialized.
      */
     template<typename T, size_t N>
-    class Array {
+    class Array
+        //! Fix CRTP impl is broken. It's initializing garbage trash
+        // : public Container<Array<T, N>, iterator::input_iter<T>>
+    {
         private:
             T array[N];
+
+            using iterator = iterator::input_iter<T>;
 
             /**
              * @brief delete the `new` operator, since the intended usage of
@@ -39,6 +46,12 @@ export namespace zero::collections {
             void* operator new(size_t) = delete;
 
         public:
+            // Iterator spected stuff
+            iterator begin() { return iterator(&array[0]); }
+            iterator end() { return iterator(&array[N]); }
+            // TODO Fix! Const impl are broken in the iterator
+            iterator begin() const { return iterator(&array[0]); }
+            iterator end() const { return iterator(&array[N]); }
 
             /**
              * @brief returns the number of elements stored in the underlying
@@ -46,7 +59,7 @@ export namespace zero::collections {
              * 
              * @return constexpr int 
              */
-            [[nodiscard]]
+            [[nodiscard]]  // TODO Follow STL convention and change it to size
             inline consteval int len() const noexcept { return N; }
 
             /**

--- a/zero/ifc/collections/array.cppm
+++ b/zero/ifc/collections/array.cppm
@@ -1,11 +1,5 @@
 /**
- * @brief A templated wrapper over a raw C-style array that mimics the std:array<T, N> 
- * 
- * @file array.cppm
- * @author Alex Vergara (pyzyryab@tutanota.com)
- * @version 0.1.0
- * @date 2022-09-25
- * @copyright Copyright (c) 2022
+ * @brief A templated wrapper over a raw C-style array that mimics the std:array<T, N>
  */
 
 export module array;

--- a/zero/ifc/collections/collections.cppm
+++ b/zero/ifc/collections/collections.cppm
@@ -1,11 +1,5 @@
 /**
- * @brief A module interface for exposing the collections of Zero 
- * 
- * @file collections.cppm
- * @author Alex Vergara (pyzyryab@tutanota.com)
- * @version 0.1.0
- * @date 2022-09-25
- * @copyright Copyright (c) 2022
+ * @brief A module interface for exposing the collections of Zero
  */
 
 export module collections;

--- a/zero/ifc/collections/container.cppm
+++ b/zero/ifc/collections/container.cppm
@@ -1,0 +1,27 @@
+/**
+ * @brief An interface for exposing the public API of the collections of the library
+ * as templated CRTP hierarchy, including concepts as constraints of part of the
+ * public API as well
+ */
+
+export module container;
+
+export namespace zero {
+    /**
+     * @brief Base interface for the hierarchy of collections
+     */
+    template <
+        typename Child, // TODO Interface the types to repr valid containers
+        // So we can get rid of the declaration (neither impl) of the methods
+        // in the base class
+        typename Iter
+        // typename ConstIter 
+    >
+    class Container {
+        public:
+            Iter begin() { return static_cast<Child*>(this)->begin(); }
+            Iter end() { return static_cast<Child*>(this)->end(); }
+            Iter begin() const { return static_cast<const Child*>(this)->begin(); }
+            Iter end() const { return static_cast<const Child*>(this)->end(); }
+    };
+}

--- a/zero/ifc/commons/concepts.cppm
+++ b/zero/ifc/commons/concepts.cppm
@@ -1,11 +1,6 @@
 /**
  * @brief Defines C++20 concepts to design constraints to be used
  * across the libraries
- * 
- * @file concepts.cppm
- * @author Alex Vergara (pyzyryab@tutanota.com)
- * @version 0.1.0
- * @date 2022-12-11
  */
 
 export module concepts;

--- a/zero/ifc/commons/typedefs.cppm
+++ b/zero/ifc/commons/typedefs.cppm
@@ -17,11 +17,6 @@
  *  
  *  Defined in header <cwchar> (since C++17) 
  *  ```
- * 
- * @file typedefs.cppm
- * @author Alex Vergara (pyzyryab@tutanota.com)
- * @version 0.1.0
- * @date 2022-10-01
  */
 
 export module typedefs;

--- a/zero/ifc/iterators/iterator.cppm
+++ b/zero/ifc/iterators/iterator.cppm
@@ -148,7 +148,7 @@ export namespace zero::iterator {
         using base_it = base_iterator<std::input_iterator_tag, T>;
 
         private:
-            T* _ptr;
+            typename base_it::pointer _ptr;
 
         public:
             input_iter<T>() = delete;
@@ -158,7 +158,7 @@ export namespace zero::iterator {
             input_iter<T>(const input_iter<T>& other) = default;
             input_iter<T>(input_iter<T>&& other) noexcept = default;
 
-            auto operator=(T* ptr) -> input_iter<T>& { _ptr = ptr; return *this; }
+            auto operator=(typename base_it::pointer ptr) -> input_iter<T>& { _ptr = ptr; return *this; }
             auto operator=(const input_iter<T>&) -> input_iter<T>& = default;
             auto operator=(input_iter<T>&&) noexcept -> input_iter<T>& = default;
 
@@ -193,7 +193,7 @@ export namespace zero::iterator {
 
             [[nodiscard]]
             friend auto operator!=(input_iter& self, input_iter& rhs) -> bool {
-                return !self._ptr != (rhs._ptr);
+                return (!*self._ptr) != *(rhs._ptr);
             }
     };
 }

--- a/zero/ifc/types/type_info.cppm
+++ b/zero/ifc/types/type_info.cppm
@@ -4,11 +4,6 @@
  * Current implementation only contains an stringifyed version of a template
  * paratemer type T when it's passed as template argument in the `type_name<T>()`
  * freestanding function, available under the `zero::types` namespace
- * 
- * @file type_info.cppm
- * @author Alex Vergara (pyzyryab@tutanota.com)
- * @version 0.1.0
- * @date 2022-12-27
  */
 
 export module type_info;

--- a/zero/ifc/zero.cppm
+++ b/zero/ifc/zero.cppm
@@ -1,10 +1,5 @@
 /**
  * @brief The base interface of the project for reexport everything, as a central point
- *  
- * @file zero.cppm
- * @author Alex Vergara (pyzyryab@tutanota.com)
- * @version 0.1.0
- * @date 2022-09-30
  */
 
 export module zero;

--- a/zero/tests/collections/array_tests.cpp
+++ b/zero/tests/collections/array_tests.cpp
@@ -4,6 +4,7 @@
 
 import std;
 import collections;
+import container;
 
 #include "../deps/catch.hpp"
 
@@ -11,6 +12,7 @@ using namespace zero;
 
 constexpr collections::Array a = collections::Array<long, 5>{1L, 2L, 3L};
 auto b = new decltype(collections::Array<int, 5>{1, 2, 3, 4, 5})[0];
+Container c = collections::Array<long, 5>{1L, 2L, 3L};
 
 TEST_CASE("Basic tests for the Array type", "[collections::Array]") {
 
@@ -59,8 +61,10 @@ SCENARIO("Scenario: The iterator library is modeled in Zero", "[Array]") {
             
     WHEN("we made our Array<T, N> iterable") {
         THEN("users can use for-range loop") {
-            for (auto value : a)
-                REQUIRE( std::is_integral<value> );
+            for (auto value : c)
+                REQUIRE( value >= 0 );
         }
     }
+
+    // TODO Const-impl are broken
 }

--- a/zork.conf
+++ b/zork.conf
@@ -29,7 +29,8 @@ interfaces:
     types/type_info.cppm
     iterators/iterator.cppm=[typedefs]
     commons/concepts.cppm=[typedefs]
-    collections/array.cppm=[typedefs, concepts]
+    collections/container.cppm
+    collections/array.cppm=[typedefs, concepts, iterator, container]
     collections/collections.cppm=[array]
     zero.cppm=[collections]
 base_impls_dir: zero/src/


### PR DESCRIPTION
- FIX: CRTP static polymorphism from the Container interface (this also should be defined in terms of a concept better)

- FIX - Const implementations of the iter are broken (we should fix them)