### PR TITLE
Const correctness and const iterators

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -7,11 +7,16 @@ import iterator;
 using namespace zero;
 
 int main() {
-    collections::Array c = collections::Array<long, 5>{1L, 2L, 3L, 4L, 5L};
+    collections::Array a = collections::Array<long, 5>{1L, 2L, 3L, 4L, 5L};
+    constexpr collections::Array b = collections::Array<long, 5>{1L, 2L, 3L, 4L, 5L};
 
     std::cout << "Iterating over the values of a zero::collection!" << std::endl;
-    for (long value : c)
-        std::cout << " - Value: " << value << std::endl;
+    for (long value : a)
+        std::cout << " - [constexpr] Value: " << value << std::endl;
+
+    std::cout << "Iterating over the values of a constexpr zero::collection!" << std::endl;
+    for (long value : b)
+        std::cout << " - [constexpr] Value: " << value << std::endl;
 
     return 0;
 }

--- a/zero/ifc/collections/array.cppm
+++ b/zero/ifc/collections/array.cppm
@@ -7,7 +7,7 @@ export module array;
 import std;
 import typedefs;
 import concepts;
-import iterator;
+export import iterator;
 import container;
 
 using namespace zero;
@@ -41,14 +41,14 @@ export namespace zero::collections {
             void* operator new(size_t) = delete;
 
         public:
-            using iterator = iterator::input_iter<T>;
+            using iterator = zero::iterator::input_iter<T>;
+            using const_iterator = zero::iterator::input_iter<const T>;
 
             // Iterator spected stuff
             iterator begin() { return iterator(&array[0]); }
             iterator end() { return iterator(&array[N]); }
-            // TODO Fix! Const impl are broken in the iterator
-            constexpr iterator begin() const { return iterator(&array[0]); }
-            constexpr iterator end() const { return iterator(&array[N]); }
+            constexpr const_iterator begin() const { return const_iterator(&array[0]); }
+            constexpr const_iterator end() const { return const_iterator(&array[N]); }
 
             /**
              * @brief returns the number of elements stored in the underlying array

--- a/zero/tests/collections/array_tests.cpp
+++ b/zero/tests/collections/array_tests.cpp
@@ -66,5 +66,10 @@ SCENARIO("Scenario: The iterator library is modeled in Zero", "[Array]") {
         }
     }
 
-    // TODO Const-impl are broken
+    WHEN("we made our Array<T, N> iterable and const compatible") {
+        THEN("so users can use for-range loop over const collections") {
+            for (auto value : a)
+                REQUIRE( value >= 0 );
+        }
+    }
 }


### PR DESCRIPTION
- Solved input_iter const correctness issues. 
- Updated Array<T, N>, it got the const version of input_iterator