### PR TITLE
Introducing mathematical symbols as unicode characters

### DIFF
--- a/zero/ifc/math/math.cppm
+++ b/zero/ifc/math/math.cppm
@@ -8,4 +8,5 @@
 export module math;
 
 export import math.ops;
+export import math.symbols;
 export import math.linear_algebra;

--- a/zero/ifc/math/symbols.cppm
+++ b/zero/ifc/math/symbols.cppm
@@ -1,21 +1,6 @@
-# The Math library
+export module math.symbols;
 
-This library aims to provide mathematical operations, operators and symbols, for being used
-in standalone mathematical operations or in more complex environments, like solving problems
-in diverse science fields.
-
-## Ops
-TODO
-
-## Linear Algebra
-TODO
-
-## Symbols
-
-This module provides the most useful mathematical symbols to be used in string representations.
-Here is the list of the ones that are implemented as the variants of the enum `MathSymbol`:
-
-```c++
+enum class MathSymbol {
     // Basic Math Operators
     Plus = 0x002B,                  // +
     Minus = 0x2212,                 // -
@@ -157,7 +142,4 @@ Here is the list of the ones that are implemented as the variants of the enum `M
     Phi = 0x03A6,                   // Φ
     Psi = 0x03A8,                   // Ψ
     Omega = 0x03A9,                 // Ω
-```
-
-> Please, everytime that a new symbol is added to the enumerated type, remember to add
-> it to this documentation for having the complete reference of the symbols implemented in the library.
+};

--- a/zero/ifc/text/print_utils.cppm
+++ b/zero/ifc/text/print_utils.cppm
@@ -1,18 +1,21 @@
 export module print_utils;
-import std;
 import formatter;
+import std;
 
 
 export namespace zero::fmt {
 
     template<typename... Args>
-    void print(const std::string& format, Args... args) {
+    constexpr void print(const std::string& format, Args... args) {
         std::cout << formatter(format, args...);
     }
 
     template<typename... Args>
-    void println(const std::string& format, Args... args) {
+    constexpr void println(const std::string& format, Args... args) {
         print(format + "\n", args...);
     }
 
+    void newln() {
+        std::cout << "\n";
+    }
 }

--- a/zero/main.cpp
+++ b/zero/main.cpp
@@ -42,7 +42,7 @@ int main() {
     // Register a new test case using a function pointer.
     TEST_CASE("Addition Test With Pointers", testPtrsAddition);
 
-    // Users can register a new test case using lambdas, avoiding to write standalone functions
+    // Users can register a new test case using lambdas, avoiding writing standalone functions
     TEST_CASE("Subtraction Test", []() {
         int result = 5 - 3;
         assertEquals(122435, result);
@@ -69,9 +69,9 @@ int main() {
 void run_containers_examples() {
     using namespace zero;
 
-    constexpr auto a = collections::Array<long, 5>{1L, 2L, 3L, 4L, 5L};
-    const Container<collections::Array<long, 5>>& b = collections::Array<long, 5>{1L, 2L, 3L, 4L, 5L};
-    Container<collections::Array<long, 5>>* c = new collections::Array<long, 5>{1L, 2L, 3L, 4L, 5L};
+    constexpr auto a = collections::Array<long, 5> {1L, 2L, 3L, 4L, 5L};
+    const Container<collections::Array<long, 5>>& b = collections::Array<long, 5> {1L, 2L, 3L, 4L, 5L};
+    Container<collections::Array<long, 5>>* c = new collections::Array<long, 5> {1L, 2L, 3L, 4L, 5L};
 
     std::cout << "Iterating over the values of a constexpr zero::collection!" << std::endl;
     std::cout << "decltype a: " << types::type_name<decltype(a)>() << std::endl;
@@ -222,7 +222,6 @@ void run_formatter_and_stylize_examples() {
     std::cout << reversedText << "\n";
     std::cout << hiddenText << "\n";
 
-
     std::cout << "\n\n#######Check combination full text########\n\n";
     std::string format_str1 = "[WARNING] {} is deprecated. Please use {} instead.";
     std::string warning_msg = formatter(format_str1, "methodA", "methodB");
@@ -239,6 +238,12 @@ void run_formatter_and_stylize_examples() {
     std::string stylized_info_msg = stylize("[INFO]", Color::GREEN, {Modifier::FAINT});
     std::string info_msg = formatter(format_str3,stylized_info_msg, "192.168.1.1");
     std::cout << info_msg << std::endl;
+
+    std::cout << "\n\n#######Check unicode symbols########\n";
+    std::string format_str4 = "{} Triple integral symbol: {}";
+    std::string stylized_info_msg_2 = stylize("[INFO]", Color::GREEN, {Modifier::FAINT});
+    std::string info_msg_2 = formatter(format_str4, stylized_info_msg_2, "∭");
+    std::cout << info_msg_2 << "\n\n";
 }
 
 void run_print_examples() {
@@ -254,5 +259,7 @@ void run_print_examples() {
     // Formatting examples with print and println
     print("Formatted print: x = {}, y = {}, z = {}", 10, 20, 30);
     println("Formatted println: x = {}, y = {}, z = {}", 10, 20, 30);
-    println("Another formatted println: The unseen {} is the deadliest {}", "Yasuo", ", but of course, he is on the enemy team");
+    println("Another formatted println: The unseen {} is the deadliest, {}", "Yasuo", "but of course, he is on the enemy team");
+
+    newln();
 }

--- a/zork_config/zork_gh_linux.toml
+++ b/zork_config/zork_gh_linux.toml
@@ -72,6 +72,8 @@ interfaces = [
         # The linear algebra library
         { file = 'math/linear_algebra/matrix.cppm', partition = { module = 'math.linear_algebra', partition_name = 'matrix' } },
         { file = 'math/linear_algebra/root.cppm', module_name = 'math.linear_algebra' },
+    # General
+    { file = 'math/symbols.cppm', module_name = 'math.symbols' },
     # Root
     { file = 'math/math.cppm' },
     

--- a/zork_config/zork_local_linux.toml
+++ b/zork_config/zork_local_linux.toml
@@ -30,35 +30,38 @@ sources = [ "tests/math/*.cpp", "tests/*.cpp" ]
 [modules]
 base_ifcs_dir = "ifc"
 interfaces = [
-#    { file = 'commons/typedefs.cppm' },
-#    { file = 'text/str_manip.cppm' },
-#    { file = 'types/type_info.cppm' },
-#    { file = 'types/type_traits.cppm' },
-#    { file = 'commons/concepts.cppm', dependencies = ['typedefs'] },
-#
+    { file = 'commons/typedefs.cppm' },
+    { file = 'text/str_manip.cppm' },
+    { file = 'text/formatter.cppm' },
+    { file = 'text/stylizer.cppm' },
+    { file = 'text/print_utils.cppm' },
+    { file = 'types/type_info.cppm' },
+    { file = 'types/type_traits.cppm' },
+    { file = 'commons/concepts.cppm', dependencies = ['typedefs'] },
+
 #    ### The testing suite
         { file = 'test-suite/assertions.cppm', partition = { module = 'tsuite' } },
     # Root
     { file = 'test-suite/suite.cppm', module_name = 'tsuite' },
-#
-#    ### Iterator library
-#        { file = 'iterators/internal/iterator_detail.cpp', partition = { module = 'iterator', partition_name = 'detail' } },
-#        { file = 'iterators/iterator_concepts.cppm', partition = { module = 'iterator', partition_name = 'concepts' } },
-#        # Modern
-#        { file = 'iterators/iterator_facade.cppm', partition = { module = 'iterator' } },
-#        { file = 'iterators/input_iterator.cppm', partition = { module = 'iterator' } },
-#        # Legacy
-#        { file = 'iterators/legacy/legacy_iterator.cppm', partition = { module = 'iterator' } },
-#        { file = 'iterators/legacy/legacy_input_iterator.cppm', partition = { module = 'iterator' } },
-#        { file = 'iterators/legacy/legacy_output_iterator.cppm', partition = { module = 'iterator' } },
-#    # Root
-#    { file = 'iterators/iterator.cppm' },
-#
-#    # The collections/containers librar
-#        { file = 'collections/container.cppm', dependencies = ['type_info'] },
-#        { file = 'collections/array.cppm', dependencies = ['typedefs', 'concepts', 'iterator', 'container'] },
-#    # Root
-#    { file = 'collections/collections.cppm', dependencies = ['array'] },
+
+    ### Iterator library
+        { file = 'iterators/internal/iterator_detail.cpp', partition = { module = 'iterator', partition_name = 'detail' } },
+        { file = 'iterators/iterator_concepts.cppm', partition = { module = 'iterator', partition_name = 'concepts' } },
+        # Modern
+        { file = 'iterators/iterator_facade.cppm', partition = { module = 'iterator' } },
+        { file = 'iterators/input_iterator.cppm', partition = { module = 'iterator' } },
+        # Legacy
+        { file = 'iterators/legacy/legacy_iterator.cppm', partition = { module = 'iterator' } },
+        { file = 'iterators/legacy/legacy_input_iterator.cppm', partition = { module = 'iterator' } },
+        { file = 'iterators/legacy/legacy_output_iterator.cppm', partition = { module = 'iterator' } },
+    # Root
+    { file = 'iterators/iterator.cppm' },
+
+    # The collections/containers librar
+        { file = 'collections/container.cppm', dependencies = ['type_info'] },
+        { file = 'collections/array.cppm', dependencies = ['typedefs', 'concepts', 'iterator', 'container'] },
+    # Root
+    { file = 'collections/collections.cppm', dependencies = ['array'] },
 
     ### Math library
         # The operations library
@@ -70,19 +73,19 @@ interfaces = [
         { file = 'math/linear_algebra/root.cppm', module_name = 'math.linear_algebra' },
     # Root
     { file = 'math/math.cppm' },
-    
-#    ### The physics library
-#        # The quantities library
-#        { file = 'physics/quantities/internal/quantities_detail.cpp', partition = { module = 'physics.quantities', partition_name = 'quantities.detail' } },
-#
-#        { file = 'physics/quantities/ratios.cppm', partition = { module = 'physics.quantities' } },
-#        { file = 'physics/quantities/units.symbols.cppm', module_name = 'units.symbols', partition = { module = 'physics.quantities' } },
-#        { file = 'physics/quantities/dimensions.cppm', module_name = 'dimensions', partition = { module = 'physics.quantities' } },
-#        { file = 'physics/quantities/units.cppm', module_name = 'units', partition = { module = 'physics.quantities' } },
-#        { file = 'physics/quantities/quantity.cppm', partition = { module = 'physics.quantities' } },
-#        { file = 'physics/quantities/physics.quantities.cppm' },
-#    # Root
-#    { file = 'physics/physics.cppm' },
+
+    ### The physics library
+        # The quantities library
+        { file = 'physics/quantities/internal/quantities_detail.cpp', partition = { module = 'physics.quantities', partition_name = 'quantities.detail' } },
+
+        { file = 'physics/quantities/ratios.cppm', partition = { module = 'physics.quantities' } },
+        { file = 'physics/quantities/units.symbols.cppm', module_name = 'units.symbols', partition = { module = 'physics.quantities' } },
+        { file = 'physics/quantities/dimensions.cppm', module_name = 'dimensions', partition = { module = 'physics.quantities' } },
+        { file = 'physics/quantities/units.cppm', module_name = 'units', partition = { module = 'physics.quantities' } },
+        { file = 'physics/quantities/quantity.cppm', partition = { module = 'physics.quantities' } },
+        { file = 'physics/quantities/physics.quantities.cppm' },
+    # Root
+    { file = 'physics/physics.cppm' },
 
     # The main interface of the project
     { file = 'zero.cppm' }

--- a/zork_config/zork_local_linux.toml
+++ b/zork_config/zork_local_linux.toml
@@ -71,6 +71,8 @@ interfaces = [
         # The linear algebra library
         { file = 'math/linear_algebra/matrix.cppm', partition = { module = 'math.linear_algebra', partition_name = 'matrix' } },
         { file = 'math/linear_algebra/root.cppm', module_name = 'math.linear_algebra' },
+        # General
+        { file = 'math/symbols.cppm', module_name = 'math.symbols' },
     # Root
     { file = 'math/math.cppm' },
 

--- a/zork_config/zork_local_windows.toml
+++ b/zork_config/zork_local_windows.toml
@@ -71,6 +71,8 @@ interfaces = [
         # The linear algebra library
         { file = 'math/linear_algebra/matrix.cppm', partition = { module = 'math.linear_algebra', partition_name = 'matrix' } },
         { file = 'math/linear_algebra/root.cppm', module_name = 'math.linear_algebra' },
+    #  General
+    { file = 'math/symbols.cppm', module_name = 'math.symbols' },
     # Root
     { file = 'math/math.cppm' },
 


### PR DESCRIPTION
This PR brings the changes reflected in #29.

Also, here we started the documentation of the `math` module, but it's still far from be completed.

Misc: Added an standalone function to the `print utils` mode for procedurally request the code to print a new line, instead of having to write an string with "\n", or call std::cout (this avoids to flush the buffer on every new line).